### PR TITLE
A few bugfixes, fontstash improvements, and REAME update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,32 @@ Strokes and fills are generated using the Stroker struct (`src/vg/stroker.cpp, .
 7. Fills with image patterns can be colored.
 8. FontStash: glyph hashing uses BKDR (seems to give better distribution of glyphs in the LUT; fewer collisions when searching for cached glyphs)
 9. FontStash: optional (compile-time flag) caching of glyph indices and kerning info for ASCII chars in order to avoid repeated calls to stbtt functions.
+10. Per-fill and per-stroke control over weather anti-aliassing geometry should be generated.
 
 ### What's not supported compared to NanoVG
 
 1. Miter limit (i.e miter joins never convert to bevel joins)
 2. Polygon holes (they can be emulated using clip in/out regions)
-3. Variable text line height
+3. Variable text line height, font blur effect, and letter-spacing control
 4. Skew transformation matrix
+
+### Example
+
+For an example on how to use this library, take a look [here](https://github.com/jdryg/bgfx/blob/xx-vg-renderer/examples/xx-vg-renderer/vg-renderer.cpp).
+
+### A few tips when porting from NanoVG.
+
+ - `nvgBezierTo` should be replaced by `vg::cubicTo`. Note that there is also `vg::quadraticTo` for a lower degree bezier.
+ - `nvgSave` and `nvgRestore` are to be replaced by `vg::pushState()` and `vg::popState()`.
+ - Thanks to the support for command lists, you may want to render your UI in layers, where every layer is a command list.
+   This way, you can still traverse the UI-tree widget by widget, but store draw commands onto the command lists per layer, which can greatly reduce state changes.
+   For example you may have a layer for widget shapes and outlines, and a layer for text.
+ - When implementing UI widget with perfectly rectanglar shape, you may consider omitting the anti-aliassing setting to generate less geometry.
+ - When using a gradient fill that will be fully transparent at the edge of the shape, you may likely also want to not generate anti-aliassing geometry.
+ - vg-renderer uses `uint32_t` as colors, instead of a struct of 4 floats.
+   When converting, you might want to consider to use `vg::color4ub` instead of `vg::color4f`.
+   Also note that there are a few predefined colors available in `vg::Colors::`.
+
 
 ### Images
 
@@ -46,3 +65,30 @@ Demo
 Custom gradients (indexed triangle lists w/ per-vertex colors)
 
 [![Gradients](https://raw.githubusercontent.com/jdryg/vg-renderer/master/img/vgrenderer_colorwheel.png)](https://raw.githubusercontent.com/jdryg/vg-renderer/master/img/vgrenderer_colorwheel.png)
+
+### Using this in your project
+
+In your project, you can add these files as a new CMake target, using the following, assuming you have this project as a submodule in a folder `ext/`:
+
+```cmake
+add_library(vg-renderer STATIC
+    "ext/vg-renderer/src/vg.cpp"
+    "ext/vg-renderer/src/stroker.cpp"
+    "ext/vg-renderer/src/path.cpp"
+    "ext/vg-renderer/src/vg_util.cpp"
+    "ext/vg-renderer/src/libs/fontstash.cpp"
+    "ext/vg-renderer/src/libs/stb_truetype.cpp"
+
+    "ext/vg-renderer/src/libtess2/bucketalloc.c"
+    "ext/vg-renderer/src/libtess2/dict.c"
+    "ext/vg-renderer/src/libtess2/geom.c"
+    "ext/vg-renderer/src/libtess2/mesh.c"
+    "ext/vg-renderer/src/libtess2/priorityq.c"
+    "ext/vg-renderer/src/libtess2/sweep.c"
+    "ext/vg-renderer/src/libtess2/tess.c"
+    )
+target_include_directories(vg-renderer PUBLIC "ext/vg-renderer/include/")
+# Add the bgfx and bx libraries to link with this target:
+# I made a macro in my project that does this. You can roll your own.
+link_bgfx_libs(vg-renderer Release)
+```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Strokes and fills are generated using the Stroker struct (`src/vg/stroker.cpp, .
 7. Fills with image patterns can be colored.
 8. FontStash: glyph hashing uses BKDR (seems to give better distribution of glyphs in the LUT; fewer collisions when searching for cached glyphs)
 9. FontStash: optional (compile-time flag) caching of glyph indices and kerning info for ASCII chars in order to avoid repeated calls to stbtt functions.
-10. Per-fill and per-stroke control over weather anti-aliassing geometry should be generated.
+10. Per-fill and per-stroke control over whether anti-aliasing geometry should be generated.
 
 ### What's not supported compared to NanoVG
 
@@ -36,13 +36,13 @@ For an example on how to use this library, take a look [here](https://github.com
 
 ### A few tips when porting from NanoVG.
 
- - `nvgBezierTo` should be replaced by `vg::cubicTo`. Note that there is also `vg::quadraticTo` for a lower degree bezier.
+ - `nvgBezierTo` should be replaced by `vg::cubicTo`. Note that there is also `vg::quadraticTo` for a lower degree Bezier curve.
  - `nvgSave` and `nvgRestore` are to be replaced by `vg::pushState()` and `vg::popState()`.
  - Thanks to the support for command lists, you may want to render your UI in layers, where every layer is a command list.
    This way, you can still traverse the UI-tree widget by widget, but store draw commands onto the command lists per layer, which can greatly reduce state changes.
    For example you may have a layer for widget shapes and outlines, and a layer for text.
- - When implementing UI widget with perfectly rectanglar shape, you may consider omitting the anti-aliassing setting to generate less geometry.
- - When using a gradient fill that will be fully transparent at the edge of the shape, you may likely also want to not generate anti-aliassing geometry.
+ - When implementing UI widget with perfectly rectangular shape, you may consider omitting the anti-aliasing setting to generate less geometry.
+ - When using a gradient fill that will be fully transparent at the edge of the shape, you may likely also want to not generate anti-aliasing geometry.
  - vg-renderer uses `uint32_t` as colors, instead of a struct of 4 floats.
    When converting, you might want to consider to use `vg::color4ub` instead of `vg::color4f`.
    Also note that there are a few predefined colors available in `vg::Colors::`.
@@ -68,7 +68,7 @@ Custom gradients (indexed triangle lists w/ per-vertex colors)
 
 ### Using this in your project
 
-In your project, you can add these files as a new CMake target, using the following, assuming you have this project as a submodule in a folder `ext/`:
+In your project, you can add these files as a new CMake target, using the following, assuming you have this project as a submodule in a folder `ext/vg-renderer`:
 
 ```cmake
 add_library(vg-renderer STATIC

--- a/include/vg/inline/vg.inl
+++ b/include/vg/inline/vg.inl
@@ -56,6 +56,41 @@ inline Color colorHSB(float hue, float sat, float brightness)
 	return 0xFF000000 | (b << 16) | (g << 8) | (r);
 }
 
+inline float _hue_helper(float h, float m1, float m2)
+{
+	if (h < 0) h += 1;
+	if (h > 1) h -= 1;
+	if (h < 1.0f/6.0f)
+		return m1 + (m2 - m1) * h * 6.0f;
+	else if (h < 3.0f/6.0f)
+		return m2;
+	else if (h < 4.0f/6.0f)
+		return m1 + (m2 - m1) * (2.0f/3.0f - h) * 6.0f;
+	return m1;
+}
+
+inline Color colorHSL(float hue, float sat, float lightness, float alpha)
+{
+	float m1, m2;
+	hue = bx::mod(hue, 1.0f);
+	if (hue < 0.0f) hue += 1.0f;
+	sat = bx::clamp<float>(sat, 0.0f, 1.0f);
+	lightness = bx::clamp<float>(lightness, 0.0f, 1.0f);
+	m2 = lightness <= 0.5f ? (lightness * (1 + sat)) : (lightness + sat - lightness * sat);
+	m1 = 2 * lightness - m2;
+	float fr = bx::clamp<float>(_hue_helper(hue + 1.0f/3.0f, m1, m2), 0.0f, 1.0f);
+	float fg = bx::clamp<float>(_hue_helper(hue, m1, m2), 0.0f, 1.0f);
+	float fb = bx::clamp<float>(_hue_helper(hue - 1.0f/3.0f, m1, m2), 0.0f, 1.0f);
+	float fa = alpha;
+
+	uint32_t r = (uint32_t)bx::floor(fr * 255.0f);
+	uint32_t g = (uint32_t)bx::floor(fg * 255.0f);
+	uint32_t b = (uint32_t)bx::floor(fb * 255.0f);
+	uint32_t a = (uint32_t)bx::floor(fa * 255.0f);
+
+	return (a << 24) | (b << 16) | (g << 8) | (r);
+}
+
 inline Color colorSetAlpha(Color c, uint8_t a)
 {
 	return (c & VG_COLOR_RGB_MASK) | ((uint32_t)a << VG_COLOR_ALPHA_SHIFT);

--- a/include/vg/vg.h
+++ b/include/vg/vg.h
@@ -104,6 +104,7 @@ typedef uint32_t Color;
 Color color4f(float r, float g, float b, float a);
 Color color4ub(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 Color colorHSB(float h, float s, float b);
+Color colorHSL(float h, float s, float l, float a=1.0f);
 Color colorSetAlpha(Color c, uint8_t a);
 uint8_t colorGetRed(Color c);
 uint8_t colorGetGreen(Color c);

--- a/include/vg/vg.h
+++ b/include/vg/vg.h
@@ -5,7 +5,7 @@
 #include <bx/math.h>
 
 #ifndef VG_CONFIG_DEBUG
-#	define VG_CONFIG_DEBUG 1
+#	define VG_CONFIG_DEBUG 0
 #endif
 
 #ifndef VG_CONFIG_ENABLE_SHAPE_CACHING

--- a/include/vg/vg.h
+++ b/include/vg/vg.h
@@ -5,7 +5,7 @@
 #include <bx/math.h>
 
 #ifndef VG_CONFIG_DEBUG
-#	define VG_CONFIG_DEBUG 0
+#	define VG_CONFIG_DEBUG 1
 #endif
 
 #ifndef VG_CONFIG_ENABLE_SHAPE_CACHING

--- a/src/libs/fontstash.cpp
+++ b/src/libs/fontstash.cpp
@@ -2,4 +2,6 @@
 #include <bx/math.h> // bx::exp
 #include <limits.h>  // INT_MIN, INT_MAX
 #define FONTSTASH_IMPLEMENTATION
+#define FONS_GLYPH_KERN_ARRAY 0
+#define FONS_GLYPH_KERN_NONZERO_BITMAP 1
 #include "fontstash.h"

--- a/src/libs/fontstash.cpp
+++ b/src/libs/fontstash.cpp
@@ -2,6 +2,6 @@
 #include <bx/math.h> // bx::exp
 #include <limits.h>  // INT_MIN, INT_MAX
 #define FONTSTASH_IMPLEMENTATION
-#define FONS_GLYPH_KERN_ARRAY 0
-#define FONS_GLYPH_KERN_NONZERO_BITMAP 1
+#define FONS_GLYPH_KERN_ARRAY_ASCII 1
+#define FONS_GLYPH_KERN_NONZERO_CODEMAP 1
 #include "fontstash.h"

--- a/src/libs/fontstash.h
+++ b/src/libs/fontstash.h
@@ -19,7 +19,7 @@
 #ifndef FONS_H
 #define FONS_H
 
-#include <bx/string.h>
+#include <assert.h>
 
 #define FONS_INVALID -1
 
@@ -572,7 +572,6 @@ int fons__tt_loadFont(FONScontext *context, FONSttFontImpl *font, unsigned char 
 			int non_zero_kern = 0;
 			for (int second_cp = FONS_FIRST_ASCII_CODEPOINT; second_cp <= FONS_LAST_ASCII_CODEPOINT; ++second_cp) {
 				int second = fons__tt_getGlyphIndex(font, second_cp);
-				//bx::printf("Codepoint %x -> Glyph idx %d\n", second_cp, second);
 				for (int first_cp = FONS_FIRST_ASCII_CODEPOINT; first_cp <= FONS_LAST_ASCII_CODEPOINT; ++first_cp) {
 					int first = fons__tt_getGlyphIndex(font, first_cp);
 					// MC: Do a lookup, which will fetch and cache the result.
@@ -583,9 +582,8 @@ int fons__tt_loadFont(FONScontext *context, FONSttFontImpl *font, unsigned char 
 					non_zero_kern += (value != 0);
 				}
 			}
-			assert(min_kern < INT16_MIN);
-			assert(max_kern > INT16_MAX);
-			//bx::printf("Kern range: %d -> %d, non-zero count: %d, num_glyphs: %d\n", min_kern, max_kern, non_zero_kern, rangeGlyphIndicesAscii);
+			assert(min_kern >= INT16_MIN);
+			assert(max_kern <= INT16_MAX);
 		}
 #endif
 	}

--- a/src/libs/fontstash.h
+++ b/src/libs/fontstash.h
@@ -255,7 +255,7 @@ void fonsDrawDebug(FONScontext* s, float x, float y);
 #include FT_ADVANCES_H
 #include <math.h>
 
-#	include <malloc.h>
+#	include <stdlib.h>
 #	include <string.h>
 #ifndef FONSmalloc
 #define FONSmalloc malloc
@@ -370,7 +370,7 @@ int fons__tt_getGlyphKernAdvance(FONSttFontImpl *font, int glyph1, int glyph2)
 static void* fons__tmpalloc(size_t size, void* up);
 static void fons__tmpfree(void* ptr, void* up);
 #else
-#	include <malloc.h>
+#	include <stdlib.h>
 #	include <string.h>
 #ifndef FONSmalloc
 #define FONSmalloc malloc

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -1,6 +1,14 @@
 #include <vg/path.h>
 #include <bx/allocator.h>
 
+#define BX_ALLOC(allocator, size) bx::alloc(allocator, size)
+#define BX_FREE(allocator, ptr) bx::free(allocator, ptr)
+#define BX_ALIGNED_ALLOC(allocator, size, align) bx::alignedAlloc(allocator, size, align)
+#define BX_ALIGNED_FREE(allocator, ptr, align) bx::alignedFree(allocator, ptr, align)
+#define BX_REALLOC(allocator, ptr, size) bx::realloc(allocator, ptr, size)
+#define BX_ALIGNED_REALLOC(allocator, ptr, size, align) bx::alignedRealloc(allocator, ptr, size, align)
+#define BX_DELETE(allocator, obj) bx::deleteObject(allocator, obj)
+
 namespace vg
 {
 struct Path

--- a/src/stroker.cpp
+++ b/src/stroker.cpp
@@ -5,6 +5,14 @@
 #include <bx/math.h>
 #include <string.h> // memcpy
 
+#define BX_ALLOC(allocator, size) bx::alloc(allocator, size)
+#define BX_FREE(allocator, ptr) bx::free(allocator, ptr)
+#define BX_ALIGNED_ALLOC(allocator, size, align) bx::alignedAlloc(allocator, size, align)
+#define BX_ALIGNED_FREE(allocator, ptr, align) bx::alignedFree(allocator, ptr, align)
+#define BX_REALLOC(allocator, ptr, size) bx::realloc(allocator, ptr, size)
+#define BX_ALIGNED_REALLOC(allocator, ptr, size, align) bx::alignedRealloc(allocator, ptr, size, align)
+#define BX_DELETE(allocator, obj) bx::deleteObject(allocator, obj)
+
 BX_PRAGMA_DIAGNOSTIC_IGNORED_MSVC(4127) // conditional expression is constant
 BX_PRAGMA_DIAGNOSTIC_IGNORED_MSVC(4456) // declaration of X hides previous local decleration
 BX_PRAGMA_DIAGNOSTIC_IGNORED_CLANG_GCC("-Wshadow")
@@ -214,7 +222,9 @@ void destroyStroker(Stroker* stroker)
 		tessDeleteTess(stroker->m_Tesselator);
 	}
 
-	BX_ALIGNED_FREE(allocator, stroker->m_libTessAllocator.m_Buffer, 16);
+	if (stroker->m_libTessAllocator.m_Buffer) {
+		BX_ALIGNED_FREE(allocator, stroker->m_libTessAllocator.m_Buffer, 16);
+	}
 
 	BX_FREE(allocator, stroker);
 }

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -30,6 +30,14 @@
 #include "shaders/vs_stencil.bin.h"
 #include "shaders/fs_stencil.bin.h"
 
+#define BX_ALLOC(allocator, size) bx::alloc(allocator, size)
+#define BX_FREE(allocator, ptr) bx::free(allocator, ptr)
+#define BX_ALIGNED_ALLOC(allocator, size, align) bx::alignedAlloc(allocator, size, align)
+#define BX_ALIGNED_FREE(allocator, ptr, align) bx::alignedFree(allocator, ptr, align)
+#define BX_REALLOC(allocator, ptr, size) bx::realloc(allocator, ptr, size)
+#define BX_ALIGNED_REALLOC(allocator, ptr, size, align) bx::alignedRealloc(allocator, ptr, size, align)
+#define BX_DELETE(allocator, obj) bx::deleteObject(allocator, obj)
+
 BX_PRAGMA_DIAGNOSTIC_IGNORED_MSVC(4706) // assignment within conditional expression
 
 #define VG_CONFIG_MIN_FONT_SCALE                 0.1f
@@ -1012,7 +1020,7 @@ void destroyContext(Context* ctx)
 	BX_DELETE(allocator, ctx->m_DataPoolMutex);
 #endif
 
-	BX_FREE(allocator, ctx);
+	BX_ALIGNED_FREE(allocator, ctx, 8);
 }
 
 void begin(Context* ctx, uint16_t viewID, uint16_t canvasWidth, uint16_t canvasHeight, float devicePixelRatio)

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -2214,7 +2214,6 @@ ImageHandle createImage(Context* ctx, uint16_t w, uint16_t h, uint32_t flags, co
 
 		bgfx::updateTexture2D(tex->m_bgfxHandle, 0, 0, 0, 0, tex->m_Width, tex->m_Height, mem);
 	}
-	bx::printf("[VB] createImage() : img=%hu, texture=%hu\n", handle.idx, tex->m_bgfxHandle.idx);
 
 	return handle;
 }
@@ -2244,7 +2243,6 @@ ImageHandle createImage(Context* ctx, uint32_t flags, const bgfx::TextureHandle&
 	tex->m_Owned = false;
 
 	tex->m_bgfxHandle.idx = bgfxTextureHandle.idx;
-	bx::printf("[VB] createImage() : img=%hu, texture=%hu\n", handle.idx, tex->m_bgfxHandle.idx);
 
 	return handle;
 }


### PR DESCRIPTION
I recently switched SilverNode from NanoVG to vg-renderer, which was a fun experience. The API is good, and I like the library. I did however run into a few problems which I fixed along the way. This is a PR with all the fixes and improvements.

Notably, regarding fontstash, there is a problem with the way the kern array was constructed if the range of ASCII characters is huge. A font I was testing with has some ASCII letters in really low glyph indexes, and some other ASCII characters in really high glyph indices. The result was a range of 2500 glyphs. The kern array gets allocated as the square of that, which was super slow to both allocate and then fill the kern array with 2500*2500 looked up kern values.

So to fix this, I did four things:
 - introduce an inverse mapping from glyph index to codepoint to be able to compact the kern array to be really only 100*100 approximately for only the selected range within ASCII.
 - reduce the kerning array datatype from `int` to `int16_t`.
 - use Rosenberg-Strong's pairing function as indexing scheme to map a glyph-glyph pair to an index, in an attempt to get more relevant entries in the table to be closer together: ![pairing functions](https://hbfs.wordpress.com/wp-content/uploads/2018/07/rosenberg-4.png).
 - introduce a 2-bit-per-glyph caching system that can optimize performance for other glyph combinations to remember whether the kerning was zero or not (most combinations actually are zero for my tests). This saves the lookup work in the TTF file. This system is not great as it still only covers the glyph index range determined by highest and lowest ASCII glyph index, as I didn't seem to find a way to get the actual glyph range of the entire font.

Overall, I got font loading back from 500ms for the font to 3ms, doing these changes.