### PR TITLE
Add null checks before calls to bx::alignedFree()

### DIFF
--- a/src/path.cpp
+++ b/src/path.cpp
@@ -34,7 +34,9 @@ void destroyPath(Path* path)
 {
 	bx::AllocatorI* allocator = path->m_Allocator;
 
-	bx::alignedFree(allocator, path->m_Vertices, 16);
+    if (path->m_Vertices) {
+        bx::alignedFree(allocator, path->m_Vertices, 16);
+    }
 	bx::free(allocator, path->m_SubPaths);
 	bx::free(allocator, path);
 }

--- a/src/stroker.cpp
+++ b/src/stroker.cpp
@@ -206,9 +206,17 @@ void destroyStroker(Stroker* stroker)
 {
 	bx::AllocatorI* allocator = stroker->m_Allocator;
 
-	bx::alignedFree(allocator, stroker->m_PosBuffer, 16);
-	bx::alignedFree(allocator, stroker->m_ColorBuffer, 16);
-	bx::alignedFree(allocator, stroker->m_IndexBuffer, 16);
+    if (stroker->m_PosBuffer) {
+        bx::alignedFree(allocator, stroker->m_PosBuffer, 16);
+    }
+    
+    if (stroker->m_ColorBuffer) {
+        bx::alignedFree(allocator, stroker->m_ColorBuffer, 16);
+    }
+    
+    if (stroker->m_IndexBuffer) {
+        bx::alignedFree(allocator, stroker->m_IndexBuffer, 16);
+    }
 
 	if (stroker->m_Tesselator) {
 		tessDeleteTess(stroker->m_Tesselator);

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -908,8 +908,10 @@ void destroyContext(Context* ctx)
 		}
 
 		IndexBuffer* ib = &ctx->m_IndexBuffers[i];
-		bx::alignedFree(allocator, ib->m_Indices, 16);
-		ib->m_Indices = nullptr;
+        if (ib->m_Indices) {
+            bx::alignedFree(allocator, ib->m_Indices, 16);
+            ib->m_Indices = nullptr;
+        }
 		ib->m_Capacity = 0;
 		ib->m_Count = 0;
 	}
@@ -1006,14 +1008,20 @@ void destroyContext(Context* ctx)
 	destroyStroker(ctx->m_Stroker);
 	ctx->m_Stroker = nullptr;
 
-	bx::alignedFree(allocator, ctx->m_TextQuads, 16);
-	ctx->m_TextQuads = nullptr;
+    if (ctx->m_TextQuads) {
+        bx::alignedFree(allocator, ctx->m_TextQuads, 16);
+        ctx->m_TextQuads = nullptr;
+    }
 
-	bx::alignedFree(allocator, ctx->m_TextVertices, 16);
-	ctx->m_TextVertices = nullptr;
+    if (ctx->m_TextVertices) {
+        bx::alignedFree(allocator, ctx->m_TextVertices, 16);
+        ctx->m_TextVertices = nullptr;
+    }
 
-	bx::alignedFree(allocator, ctx->m_TransformedVertices, 16);
-	ctx->m_TransformedVertices = nullptr;
+    if (ctx->m_TransformedVertices) {
+        bx::alignedFree(allocator, ctx->m_TransformedVertices, 16);
+        ctx->m_TransformedVertices = nullptr;
+    }
 
 #if BX_CONFIG_SUPPORTS_THREADING
 	bx::deleteObject(allocator, ctx->m_DataPoolMutex);


### PR DESCRIPTION
Previously, BX_ALIGNED_FREE was going through bx::realloc which includes a null check. However, bx::alignedFree() directly calls into bx::free() which will crash when passed a null pointer. These extra checks prevent crashes introduced after the migration from BX_ALIGNED_FREE to bx::alignedFree.

Fixes https://github.com/jdryg/vg-renderer/issues/31.