### PR TITLE
feat: editor config file to make contributions more consistent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset      = utf-8
+indent_style = tab
+indent_size  = 4
+end_of_line  = lf
+max_line_length = 100
+insert_final_newline     = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
I found my initial PR did not match spacing (used spaces instead of tabs). By adding an `.editorconfig` file we can make it easier for contributors to match the existing line and spacing styles

For this I have simply copied the bgfx `.editorconfig` and removed the bgfx specific subfolder overrides