### PR TITLE
feat: reset view transform flag

### DIFF
--- a/include/vg/vg.h
+++ b/include/vg/vg.h
@@ -402,7 +402,7 @@ Context* createContext(bx::AllocatorI* allocator, const ContextConfig* cfg = nul
 void destroyContext(Context* ctx);
 
 void begin(Context* ctx, uint16_t viewID, uint16_t canvasWidth, uint16_t canvasHeight, float devicePixelRatio);
-void end(Context* ctx);
+void end(Context* ctx, bool resetViewTransform = true);
 void frame(Context* ctx);
 const Stats* getStats(Context* ctx);
 

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -1072,7 +1072,7 @@ void begin(Context* ctx, uint16_t viewID, uint16_t canvasWidth, uint16_t canvasH
 	ctx->m_NextImagePatternID = 0;
 }
 
-void end(Context* ctx)
+void end(Context* ctx, bool resetViewTransform)
 {
 	VG_CHECK(ctx->m_StateStackTop == 0, "pushState()/popState() mismatch");
 	VG_CHECK(!isValid(ctx->m_ActiveCommandList), "endCommandList() hasn't been called");
@@ -1144,11 +1144,13 @@ void end(Context* ctx)
 	const uint16_t canvasHeight = ctx->m_CanvasHeight;
 	const float devicePixelRatio = ctx->m_DevicePixelRatio;
 
-	float viewMtx[16];
-	float projMtx[16];
-	bx::mtxIdentity(viewMtx);
-	bx::mtxOrtho(projMtx, 0.0f, (float)canvasWidth, (float)canvasHeight, 0.0f, 0.0f, 1.0f, 0.0f, bgfx::getCaps()->homogeneousDepth);
-	bgfx::setViewTransform(viewID, viewMtx, projMtx);
+	if (resetViewTransform) {
+		float viewMtx[16];
+		float projMtx[16];
+		bx::mtxIdentity(viewMtx);
+		bx::mtxOrtho(projMtx, 0.0f, (float)canvasWidth, (float)canvasHeight, 0.0f, 0.0f, 1.0f, 0.0f, bgfx::getCaps()->homogeneousDepth);
+		bgfx::setViewTransform(viewID, viewMtx, projMtx);
+	}
 
 	uint16_t prevScissorRect[4] = { 0, 0, canvasWidth, canvasHeight};
 	uint16_t prevScissorID = UINT16_MAX;


### PR DESCRIPTION
This adds an optional parameter to `end` to reset the view transform, changing its signature from:

`void end(Context* ctx);`

to

`void end(Context* ctx, bool resetViewTransform = true);`

We set this to `false` when integrating `vg-renderer` with our renderer, as resetting the view transform impacts the rendering state outside of `vg-renderer` in our integration.

We have tried to preserve the public API here, in that existing uses should not be affected. However I would be happy to move this setting elsewhere (like `ContextConfig`) if it seems more appropriate.