### PR TITLE
feat: support for specifying view transform reset on end()

### DIFF
--- a/include/vg/vg.h
+++ b/include/vg/vg.h
@@ -333,6 +333,7 @@ struct ContextConfig
 	uint32_t m_MaxVBVertices;       // default: 65536
 	uint32_t m_FontAtlasImageFlags; // default: ImageFlags::Filter_Bilinear
 	uint32_t m_MaxCommandListDepth; // default: 16
+	bool m_ResetViewTransformOnEnd; // default: true
 };
 
 struct Stats

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -725,7 +725,8 @@ Context* createContext(bx::AllocatorI* allocator, const ContextConfig* userCfg)
 		256,                         // m_MaxCommandLists
 		65536,                       // m_MaxVBVertices
 		ImageFlags::Filter_Bilinear, // m_FontAtlasImageFlags
-		16                           // m_MaxCommandListDepth
+		16,                          // m_MaxCommandListDepth
+		true                         // m_ResetViewTransformOnEnd
 	};
 
 	const ContextConfig* cfg = userCfg ? userCfg : &defaultConfig;
@@ -1144,11 +1145,13 @@ void end(Context* ctx)
 	const uint16_t canvasHeight = ctx->m_CanvasHeight;
 	const float devicePixelRatio = ctx->m_DevicePixelRatio;
 
-	float viewMtx[16];
-	float projMtx[16];
-	bx::mtxIdentity(viewMtx);
-	bx::mtxOrtho(projMtx, 0.0f, (float)canvasWidth, (float)canvasHeight, 0.0f, 0.0f, 1.0f, 0.0f, bgfx::getCaps()->homogeneousDepth);
-	bgfx::setViewTransform(viewID, viewMtx, projMtx);
+	if (ctx->m_Config.m_ResetViewTransformOnEnd) {
+		float viewMtx[16];
+		float projMtx[16];
+		bx::mtxIdentity(viewMtx);
+		bx::mtxOrtho(projMtx, 0.0f, (float)canvasWidth, (float)canvasHeight, 0.0f, 0.0f, 1.0f, 0.0f, bgfx::getCaps()->homogeneousDepth);
+		bgfx::setViewTransform(viewID, viewMtx, projMtx);
+	}
 
 	uint16_t prevScissorRect[4] = { 0, 0, canvasWidth, canvasHeight};
 	uint16_t prevScissorID = UINT16_MAX;


### PR DESCRIPTION
Implemented as an option in ContextConfig, defaults to `true`

When set to `true` the view transform is reset to the default ortho projection on `end()`