### PR TITLE
fix: re-enabled code to detect degenerate paths and early-out

### DIFF
--- a/src/path.cpp
+++ b/src/path.cpp
@@ -757,7 +757,6 @@ static void pathAddVertex(Path* path, float x, float y)
 	VG_CHECK(path->m_CurSubPath, "No path");
 	VG_CHECK(!path->m_CurSubPath->m_IsClosed, "Cannot add new vertices to a closed path");
 
-#if 0
 	if (path->m_CurSubPath->m_NumVertices != 0) {
 		const uint32_t lastVertexID = path->m_CurSubPath->m_FirstVertexID + (path->m_CurSubPath->m_NumVertices - 1);
 		const float* lastVertex = &path->m_Vertices[lastVertexID << 1];
@@ -769,7 +768,6 @@ static void pathAddVertex(Path* path, float x, float y)
 			return;
 		}
 	}
-#endif
 
 	float* v = pathAllocVertices(path, 1);
 	v[0] = x;


### PR DESCRIPTION
This is intended to fix the issue documented here https://github.com/jdryg/vg-renderer/issues/38