### PR TITLE
Make Fontstash Optional

### DIFF
--- a/include/vg/inline/vg.inl
+++ b/include/vg/inline/vg.inl
@@ -379,6 +379,11 @@ inline void clTextBox(CommandListRef& ref, const TextConfig& cfg, float x, float
 	clTextBox(ref.m_Context, ref.m_Handle, cfg, x, y, breakWidth, str, end, textboxFlags);
 }
 
+inline void clCustomCallback(CommandListRef&ref, const uint32_t arg1, const uint32_t arg2)
+{
+	clCustomCallback(ref.m_Context, ref.m_Handle, arg1, arg2);
+}
+
 inline void clSubmitCommandList(CommandListRef& ref, CommandListHandle child)
 {
 	clSubmitCommandList(ref.m_Context, ref.m_Handle, child);

--- a/include/vg/inline/vg.inl
+++ b/include/vg/inline/vg.inl
@@ -379,9 +379,9 @@ inline void clTextBox(CommandListRef& ref, const TextConfig& cfg, float x, float
 	clTextBox(ref.m_Context, ref.m_Handle, cfg, x, y, breakWidth, str, end, textboxFlags);
 }
 
-inline void clCustomCallback(CommandListRef&ref, const uint32_t arg1, const uint32_t arg2)
+inline void clCustomCallback(CommandListRef&ref, void* usrPtr, const uint32_t arg1, const uint32_t arg2)
 {
-	clCustomCallback(ref.m_Context, ref.m_Handle, arg1, arg2);
+	clCustomCallback(ref.m_Context, ref.m_Handle, usrPtr, arg1, arg2);
 }
 
 inline void clSubmitCommandList(CommandListRef& ref, CommandListHandle child)

--- a/include/vg/vg.h
+++ b/include/vg/vg.h
@@ -468,7 +468,7 @@ void measureTextBox(Context* ctx, const TextConfig& cfg, float x, float y, float
 float getTextLineHeight(Context* ctx, const TextConfig& cfg);
 int textBreakLines(Context* ctx, const TextConfig& cfg, const char* str, const char* end, float breakRowWidth, TextRow* rows, int maxRows, uint32_t flags);
 int textGlyphPositions(Context* ctx, const TextConfig& cfg, float x, float y, const char* text, const char* end, GlyphPosition* positions, int maxPositions);
-void customCallback(Context* ctx, const uint32_t arg1, const uint32_t arg2);
+void customCallback(Context* ctx, void* usrPtr, const uint32_t arg1, const uint32_t arg2);
 
 /*
  * pos: A list of 2D vertices (successive x,y pairs)
@@ -544,7 +544,7 @@ void clSetGlobalAlpha(Context* ctx, CommandListHandle handle, float alpha);
 
 void clText(Context* ctx, CommandListHandle handle, const TextConfig& cfg, float x, float y, const char* str, const char* end);
 void clTextBox(Context* ctx, CommandListHandle handle, const TextConfig& cfg, float x, float y, float breakWidth, const char* str, const char* end, uint32_t textboxFlags);
-void clCustomCallback(Context* ctx, CommandListHandle handle, const uint32_t arg1, const uint32_t arg2);
+void clCustomCallback(Context* ctx, CommandListHandle handle, void* usrPtr, const uint32_t arg1, const uint32_t arg2);
 
 void clSubmitCommandList(Context* ctx, CommandListHandle parent, CommandListHandle child);
 
@@ -562,7 +562,7 @@ int textBreakLines(Context* ctx, FontHandle fontHandle, float fontSize, uint32_t
 int textGlyphPositions(Context* ctx, FontHandle fontHandle, float fontSize, uint32_t alignment, float x, float y, const char* str, const char* end, GlyphPosition* positions, int maxPositions);
 
 // Call backs added
-typedef void (*CustomCallbackFn) (Context* ctx, const uint32_t arg1, const uint32_t arg2);
+typedef void (*CustomCallbackFn) (Context* ctx, void* usrPtr, const uint32_t arg1, const uint32_t arg2);
 extern CustomCallbackFn gCustomCallback;
 
 // Helper struct and functions to avoid moving around both a Context and a CommandListHandle.
@@ -616,7 +616,7 @@ void clSetGlobalAlpha(CommandListRef &ref, float alpha);
 
 void clText(CommandListRef& ref, const TextConfig& cfg, float x, float y, const char* str, const char* end);
 void clTextBox(CommandListRef& ref, const TextConfig& cfg, float x, float y, float breakWidth, const char* str, const char* end, uint32_t textboxFlags);
-void clCustomCallback(CommandListRef&ref, const uint32_t arg1, const uint32_t arg2);
+void clCustomCallback(CommandListRef&ref, void* usrPtr, const uint32_t arg1, const uint32_t arg2);
 void clSubmitCommandList(CommandListRef& ref, CommandListHandle child);
 }
 

--- a/include/vg/vg.h
+++ b/include/vg/vg.h
@@ -48,6 +48,7 @@
 #	define VG_CONFIG_COMMAND_LIST_BEGIN_END_API 1
 #endif
 
+
 #if VG_CONFIG_DEBUG
 #include <bx/debug.h>
 
@@ -100,6 +101,7 @@ namespace bgfx
 {
 struct TextureHandle;
 }
+
 
 namespace vg
 {
@@ -466,6 +468,7 @@ void measureTextBox(Context* ctx, const TextConfig& cfg, float x, float y, float
 float getTextLineHeight(Context* ctx, const TextConfig& cfg);
 int textBreakLines(Context* ctx, const TextConfig& cfg, const char* str, const char* end, float breakRowWidth, TextRow* rows, int maxRows, uint32_t flags);
 int textGlyphPositions(Context* ctx, const TextConfig& cfg, float x, float y, const char* text, const char* end, GlyphPosition* positions, int maxPositions);
+void customCallback(Context* ctx, const uint32_t arg1, const uint32_t arg2);
 
 /*
  * pos: A list of 2D vertices (successive x,y pairs)
@@ -541,6 +544,7 @@ void clSetGlobalAlpha(Context* ctx, CommandListHandle handle, float alpha);
 
 void clText(Context* ctx, CommandListHandle handle, const TextConfig& cfg, float x, float y, const char* str, const char* end);
 void clTextBox(Context* ctx, CommandListHandle handle, const TextConfig& cfg, float x, float y, float breakWidth, const char* str, const char* end, uint32_t textboxFlags);
+void clCustomCallback(Context* ctx, CommandListHandle handle, const uint32_t arg1, const uint32_t arg2);
 
 void clSubmitCommandList(Context* ctx, CommandListHandle parent, CommandListHandle child);
 
@@ -556,6 +560,10 @@ void measureTextBox(Context* ctx, FontHandle fontHandle, float fontSize, uint32_
 float getTextLineHeight(Context* ctx, FontHandle fontHandle, float fontSize, uint32_t alignment);
 int textBreakLines(Context* ctx, FontHandle fontHandle, float fontSize, uint32_t alignment, const char* str, const char* end, float breakRowWidth, TextRow* rows, int maxRows, uint32_t flags);
 int textGlyphPositions(Context* ctx, FontHandle fontHandle, float fontSize, uint32_t alignment, float x, float y, const char* str, const char* end, GlyphPosition* positions, int maxPositions);
+
+// Call backs added
+typedef void (*CustomCallbackFn) (Context* ctx, const uint32_t arg1, const uint32_t arg2);
+extern CustomCallbackFn gCustomCallback;
 
 // Helper struct and functions to avoid moving around both a Context and a CommandListHandle.
 struct CommandListRef
@@ -608,6 +616,7 @@ void clSetGlobalAlpha(CommandListRef &ref, float alpha);
 
 void clText(CommandListRef& ref, const TextConfig& cfg, float x, float y, const char* str, const char* end);
 void clTextBox(CommandListRef& ref, const TextConfig& cfg, float x, float y, float breakWidth, const char* str, const char* end, uint32_t textboxFlags);
+void clCustomCallback(CommandListRef&ref, const uint32_t arg1, const uint32_t arg2);
 void clSubmitCommandList(CommandListRef& ref, CommandListHandle child);
 }
 

--- a/include/vg/vg.h
+++ b/include/vg/vg.h
@@ -8,6 +8,10 @@
 #	define VG_CONFIG_DEBUG 0
 #endif
 
+#ifndef VG_USE_FONTSTASH
+#	define VG_USE_FONTSTASH 1
+#endif
+
 #ifndef VG_CONFIG_ENABLE_SHAPE_CACHING
 #	define VG_CONFIG_ENABLE_SHAPE_CACHING 1
 #endif

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -8,9 +8,9 @@
 // - Allow strokes and fills with gradients and image patterns to be used as clip masks (might
 // be useful if the same command list is used both inside and outside a beginClip()/endClip() 
 // block)
-////#include <vg/vg.h>
-////#include <vg/path.h>
-////#include <vg/stroker.h>
+#include <vg/vg.h>
+#include <vg/path.h>
+#include <vg/stroker.h>
 #include "vg_util.h"
 #if VG_USE_FONTSTASH
 	#include "libs/fontstash.h"

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -1176,7 +1176,7 @@ void end(Context* ctx)
 	// Update bgfx index buffer...
 	IndexBuffer* ib = &ctx->m_IndexBuffers[ctx->m_ActiveIndexBufferID];
 	GPUIndexBuffer* gpuib = &ctx->m_GPUIndexBuffers[ctx->m_ActiveIndexBufferID];
-	const bgfx::Memory* indexMem = bgfx::makeRef(&ib->m_Indices[0], sizeof(uint16_t) * ib->m_Count, releaseIndexBufferCallback, ctx);
+	const bgfx::Memory* indexMem = bgfx::makeRef(&ib->m_Indices[0], sizeof(uint16_t) * ib->m_Count, ib->m_Count ? releaseIndexBufferCallback : 0, ctx);
 	if (!bgfx::isValid(gpuib->m_bgfxHandle)) {
 		gpuib->m_bgfxHandle = bgfx::createDynamicIndexBuffer(indexMem, BGFX_BUFFER_ALLOW_RESIZE);
 	} else {

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -8,9 +8,9 @@
 // - Allow strokes and fills with gradients and image patterns to be used as clip masks (might
 // be useful if the same command list is used both inside and outside a beginClip()/endClip() 
 // block)
-//#include <vg/vg.h>
-//#include <vg/path.h>
-//#include <vg/stroker.h>
+#include <vg/vg.h>
+#include <vg/path.h>
+#include <vg/stroker.h>
 #include "vg_util.h"
 #if VG_USE_FONTSTASH
 	#include "libs/fontstash.h"

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -867,7 +867,9 @@ Context* createContext(bx::AllocatorI* allocator, const ContextConfig* userCfg)
 
 	fonsInitString(&ctx->m_TextString);
 #else
-	ctx->m_FontImages[0] = createImage(ctx, 1, 1, cfg->m_FontAtlasImageFlags, nullptr);
+	uint8_t whiteImg[4];
+	memset(&whiteImg[0], 0xff, 4);
+	ctx->m_FontImages[0] = createImage(ctx, 1, 1, cfg->m_FontAtlasImageFlags, &whiteImg[0]);
 	VG_CHECK(isValid(ctx->m_FontImages[0]), "Failed to initialize dummy font texture");
 #endif // VG_USE_FONTSTASH
 	return ctx;

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -4227,6 +4227,7 @@ static void ctxSetGlobalAlpha(Context* ctx, float alpha)
 }
 
 static void ctxCustomCallback(Context* ctx, void* usrPtr, const uint32_t arg1, const uint32_t arg2) {
+	ctx->m_ForceNewDrawCommand = true;
 	DrawCommand* cmd = allocDrawCommand(ctx, 0, 0, DrawCommand::Type::CustomCallback, 0);
 	cmd->m_VertexBufferID = arg1;
 	cmd->m_FirstVertexID = arg2;


### PR DESCRIPTION
I use `sdl-stb-font` (https://github.com/SnapperTT/sdl-stb-font) for font rendering which conflicts with FontStash, so I've put everything FontStash related behind an `#include` guard. By default nothing is changed but a user may disable Fontstash by setting `#define VG_USE_FONTSTASH 0` before including `vg.h`.