### PR TITLE
Add support for HSB with alpha & small optimization when rounded square is actually a circle.

### DIFF
--- a/include/vg/inline/vg.inl
+++ b/include/vg/inline/vg.inl
@@ -18,7 +18,7 @@ inline Color color4ub(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 	return VG_COLOR32(r, g, b, a);
 }
 
-inline Color colorHSB(float hue, float sat, float brightness)
+inline Color colorHSB(float hue, float sat, float brightness, float alpha)
 {
 	const float d = 1.0f / 6.0f;
 
@@ -52,8 +52,9 @@ inline Color colorHSB(float hue, float sat, float brightness)
 	uint32_t r = (uint32_t)bx::floor((fred + m) * 255.0f);
 	uint32_t g = (uint32_t)bx::floor((fgreen + m) * 255.0f);
 	uint32_t b = (uint32_t)bx::floor((fblue + m) * 255.0f);
+	uint32_t a = (uint32_t)bx::floor(alpha * 255.0f);
 
-	return 0xFF000000 | (b << 16) | (g << 8) | (r);
+	return (a << 24) | (b << 16) | (g << 8) | (r);
 }
 
 inline float _hue_helper(float h, float m1, float m2)

--- a/include/vg/vg.h
+++ b/include/vg/vg.h
@@ -103,7 +103,7 @@ typedef uint32_t Color;
 
 Color color4f(float r, float g, float b, float a);
 Color color4ub(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
-Color colorHSB(float h, float s, float b);
+Color colorHSB(float h, float s, float b, float a=1.0f);
 Color colorHSL(float h, float s, float l, float a=1.0f);
 Color colorSetAlpha(Color c, uint8_t a);
 uint8_t colorGetRed(Color c);

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -292,10 +292,17 @@ void pathRoundedRect(Path* path, float x, float y, float w, float h, float r)
 		return;
 	}
 
-	const float rx = bx::min<float>(r, bx::abs(w) * 0.5f) * bx::sign(w);
-	const float ry = bx::min<float>(r, bx::abs(h) * 0.5f) * bx::sign(h);
+	float max_r = bx::min<float>(w, h) * 0.5f;
 
-	r = bx::min<float>(rx, ry);
+	if (w == h && r >= max_r - 0.25f) {
+		pathCircle(path, x + max_r, y + max_r, max_r);
+		return;
+	}
+
+	r = bx::min<float>(r, max_r - 0.25f);
+
+	const float rx = r * bx::sign(w);
+	const float ry = r * bx::sign(h);
 
 	const float da = bx::acos((path->m_Scale * r) / ((path->m_Scale * r) + path->m_TesselationTolerance)) * 2.0f;
 	const uint32_t numPointsHalfCircle = bx::uint32_max(2, (uint32_t)bx::ceil(bx::kPi / da));

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -215,7 +215,7 @@ void pathArcTo(Path* path, float x1, float y1, float x2, float y2, float r)
 //	if (nvg__ptEquals(x0, y0, x1, y1, ctx->distTol) ||
 //		nvg__ptEquals(x1, y1, x2, y2, ctx->distTol) ||
 //		nvg__distPtSeg(x1, y1, x0, y0, x2, y2) < ctx->distTol * ctx->distTol ||
-//		radius < ctx->distTol) 
+//		radius < ctx->distTol)
 //	{
 //		nvgLineTo(ctx, x1,y1);
 //		return;
@@ -294,12 +294,12 @@ void pathRoundedRect(Path* path, float x, float y, float w, float h, float r)
 
 	float max_r = bx::min<float>(w, h) * 0.5f;
 
-	if (w == h && r >= max_r - 0.25f) {
+	if (w == h && r >= max_r - VG_EPSILON) {
 		pathCircle(path, x + max_r, y + max_r, max_r);
 		return;
 	}
 
-	r = bx::min<float>(r, max_r - 0.25f);
+	r = bx::min<float>(r, max_r);
 
 	const float rx = r * bx::sign(w);
 	const float ry = r * bx::sign(h);


### PR DESCRIPTION
 - HSB with alpha argument.
 - Fall back to rendering a circle if the rounded rectangle is square with radius >= 0.5 * size. (This PR was originally dealing with the degenerate paths issue, which was fixed by #39, but I thought that this trick of transitioning to circle is still worth keeping°